### PR TITLE
Add missing patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the "vsc-fennel" extension will be documented in this fil
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
+### Added
+* macros: pick-args,pick-values,import-macros,macrodebug (fennel 0.4.0)
+* bitop specials: band,bnot,bor,bxor,lshift,rshift (fennel 0.4.0)
+* macro: with-open (fennel 0.4.2)
+* macros: collect,icollect (fennel 0.8.0)
+* macro: ?. (fennel 0.9.0)
 
 ## [0.1.1] - 2021-01-17
 ### Fixed

--- a/syntaxes/fennel.tmLanguage.json
+++ b/syntaxes/fennel.tmLanguage.json
@@ -111,7 +111,7 @@
 			"patterns": [
 				{
 					"name": "keyword.special.fennel",
-					"match": "\\#|\\%|\\+|\\*|(\\.)?\\.|(\\/)?\\/|:|<=?|=|>=?|\\^"
+					"match": "\\#|\\%|\\+|\\*|[?][.]|(\\.)?\\.|(\\/)?\\/|:|<=?|=|>=?|\\^"
 				},
 				{
 					"name": "keyword.special.fennel",
@@ -129,7 +129,7 @@
 				{ "name": "keyword.special.fennel", "match": "set-forcibly!" },
 				{
 					"name": "keyword.special.fennel",
-					"match": "\\b(and|comment|do|doc|doto|each|eval-compiler|for|global|hashfn|if|include|lambda|length|let|local|lua|macro|macros|match|not=?|or|partial|quote|require-macros|set|tset|values|var|when|while)\\b"
+					"match": "\\b(and|band|bnot|bor|bxor|collect|comment|do|doc|doto|each|eval-compiler|for|global|hashfn|icollect|if|import-macros|include|lambda|length|let|local|lshift|lua|macro|macrodebug|macros|match|not=?|or|partial|pick-args|pick-values|quote|require-macros|rshift|set|tset|values|var|when|while|with-open)\\b"
 				},
 				{
 					"name": "keyword.control.fennel",


### PR DESCRIPTION
Nice job getting this started! I decided to poke through it to get comfortable working with the grammar format (since so many things use this TextMate grammar format, I'm going to eventually try to auto-generate the json), and noticed some of the post-0.3.0 items missing so figured I'd add them:

* macros: `pick-args`,`pick-values`,`import-macros`,`macrodebug` (fennel 0.4.0)
* bitop specials: `band`,`bnot`,`bor`,`bxor`,`lshift`,`rshift` (fennel 0.4.0)
* macro: `with-open` (fennel 0.4.2)
* macros: `collect`,`icollect` (fennel 0.8.0)
* macro: `?.` (fennel 0.9.0)

After adding `?.` I noticed an edge case of overly-greedy matching (it also matches `?..`, `?...`, `?....`), which is also present for the other non-alphanumeric specials `\\b` won't work on (`->>` also matching `->>>>`, `.foo` treating the `.` as special, etc), but that'll probably be nontrivial to fix reliably since jsonschema doesn't support  the lookbehinds added to ECMA2018, so I figured I'd just submit for now and muck with gnarly regexes later.

Thanks again!